### PR TITLE
Minor change preferring PascalCase to camelCase reference.

### DIFF
--- a/Markdown/02_Python_for_Programmers.md
+++ b/Markdown/02_Python_for_Programmers.md
@@ -135,7 +135,7 @@ in `this_is_snake_case`.
 If something represents a constant, you use all uppercase letters, as in
 `THIS_IS_A_CONSTANT`.
 
-The one exception is class names, which are "camel-cased," starting with a
+The one exception is class names, which are "pascal-cased," starting with a
 capital letter, without underscores and capitalizing intermediate words. For
 example: `ThisIsMyClass`.
 


### PR DESCRIPTION
There is some ambiguity where pascal-case and camel-case, but Microsoft's official stance is that "ThisIsPascalCase" and "thisIsCamelCase".  [Reference.](https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-1.1/x2dbyw72(v=vs.71)?redirectedfrom=MSDN)